### PR TITLE
Changed documentation URL 

### DIFF
--- a/05.Spring-Boot-Advanced/Step14.md
+++ b/05.Spring-Boot-Advanced/Step14.md
@@ -28,7 +28,7 @@ First Snippet
 ```
 
 ## Exercises
-- Find out from documentation (https://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-servlet-containers.html) how to switch to undertow!
+- Find out from documentation (https://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-web-servers.html) how to switch to undertow!
 
 ## Files List
 ### pom.xml


### PR DESCRIPTION
The documentation URL gives 404 Not Found. I changed it to current Spring Boot documentation.